### PR TITLE
Corregir navbar para dispositivos desde 320px de ancho

### DIFF
--- a/src/Icons/Icons.jsx
+++ b/src/Icons/Icons.jsx
@@ -7,8 +7,6 @@ export const IconTeamMaster = (props) => (
     viewBox="65 170.271 128.901 129.457"
     style={{
       verticalAlign: "middle",
-      marginRight: "5px",
-      marginBottom: "-5px",
     }}
     {...props}
   >
@@ -61,7 +59,6 @@ export const SortIcon = ({ className }) => (
   </svg>
 );
 
-
 export const CheckIcon = ({ className }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -73,11 +70,7 @@ export const CheckIcon = ({ className }) => (
     stroke="currentColor"
     className={className}
   >
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M5 13l4 4L19 7"
-    />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
   </svg>
 );
 

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -30,16 +30,16 @@ const Navbar = ({ showNav, setShowNav }) => {
   return (
     <header className={`${!user ? "bg-white border-b fixed w-full z-10" : ""}`}>
       <div
-        className={`mx-auto flex justify-between h-16 items-center gap-8 px-4 sm:px-6 lg:px-8 ${
+        className={`mx-auto flex justify-between h-16 items-center  px-2 sm:px-6 lg:px-8 ${
           !user && "max-w-screen-xl"
         }`}
       >
         {!user ? (
-          <div className="flex items-center justify-center">
+          <div className="flex items-center justify-center gap-2">
             <IconTeamMaster width={40} height={40} />
             <a
               href="#"
-              className="mt-4 text-xl font-semibold mb-4 text-red-500 inline-flex items-center mx-4 xl:text-3xl"
+              className="text-xl font-semibold text-red-500 inline-flex items-center sm:text-3xl"
             >
               Team<span className="text-blue-500">Master</span>
             </a>
@@ -47,7 +47,7 @@ const Navbar = ({ showNav, setShowNav }) => {
               href="https://github.com/ShaditCuber/TeamMaster"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-black ml-2 hover:text-blue-500"
+              className="text-black hover:text-blue-500 ml-0 sm:ml-2"
             >
               {!user && <GitHub fill="black" className="hover:red" />}
             </a>
@@ -67,7 +67,7 @@ const Navbar = ({ showNav, setShowNav }) => {
         <div>
           <label
             htmlFor="HeadlineAct"
-            className="block text-md font-medium text-gray-900"
+            className="block text-sm sm:text-base text-center font-medium text-gray-900"
           >
             {t("language")}
           </label>
@@ -75,7 +75,7 @@ const Navbar = ({ showNav, setShowNav }) => {
           <select
             name="HeadlineAct"
             id="HeadlineAct"
-            className="mt-1.5 w-full rounded-lg border border-gray-300 text-gray-700 sm:text-md"
+            className="w-full rounded-lg border border-gray-300 text-gray-700 text-sm sm:text-base"
             value={savedLanguage || "es"}
             onChange={(e) => changeLanguage(e)}
           >


### PR DESCRIPTION
Eliminé los márgenes del icono TeamMaster para permitir el posicionamiento de este desde su contenedor permitiendo mayor flexibilidad.

Cambie estilos del navbar para permitir su correcta representación en pantallas desde los 320px.

Antes:
![image](https://github.com/ShaditCuber/TeamMaster/assets/107561640/44a6d70c-f9bf-496e-8d6f-449452b8946d)
![image](https://github.com/ShaditCuber/TeamMaster/assets/107561640/beae9a41-fded-4138-acc3-07ddc4093e27)

Después:
![image](https://github.com/ShaditCuber/TeamMaster/assets/107561640/3d9240d5-ca64-4417-a863-978e9792e372)
![image](https://github.com/ShaditCuber/TeamMaster/assets/107561640/83107436-5cb7-47e7-9dd6-a90154d2c329)

