### PR TITLE
Corregir footer responsive y semántica HTML

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -2,26 +2,24 @@ import React from "react";
 import { IconTeamMaster } from "../../Icons/Icons";
 
 const Footer = () => {
-
   return (
     <footer className="border-t w-full">
-      <div className="mx-auto max-w-screen-xl px-4 py-2 sm:px-6 lg:px-8">
-        <div className="sm:flex sm:items-center sm:justify-between">
-          <div className="flex items-center justify-center">
-            <IconTeamMaster width={20} height={20} />
-            <a
-              href="#"
-              className="mt-4 text-xl font-semibold mb-4 text-red-500 inline-flex items-center mx-4"
-            >
-              Team<span className="text-blue-500">Master</span>
-            </a>
-          </div>
-
-          <p className="mt-4 text-center text-sm text-gray-500 lg:mt-0 lg:text-right">
-            Copyright TeamMaster &copy; {new Date().getFullYear()}. All rights reserved.
-          </p>
+      <section className="mx-auto max-w-screen-xl px-2 sm:px-6 lg:px-8 py-4 flex flex-col sm:flex-row items-center justify-between gap-y-4">
+        <div className="flex items-center justify-center gap-x-2">
+          <IconTeamMaster width={20} height={20} />
+          <a
+            href="#"
+            className="text-xl font-semibold text-red-500 inline-flex items-center"
+          >
+            Team<span className="text-blue-500">Master</span>
+          </a>
         </div>
-      </div>
+
+        <p className="text-center text-sm text-gray-500">
+          Copyright TeamMaster &copy; {new Date().getFullYear()}. All rights
+          reserved.
+        </p>
+      </section>
     </footer>
   );
 };


### PR DESCRIPTION
Mejoré la semantica del footer y eliminé DIVs que no tenían sentido.

Corregí desalineación del footer para resoluciones entre 640px y 1024px.

Antes:
![image](https://github.com/ShaditCuber/TeamMaster/assets/107561640/4ae9f65c-57b2-4c63-9c7c-013314348e67)

Después:
![image](https://github.com/ShaditCuber/TeamMaster/assets/107561640/085bed97-922c-4c2c-873f-20116aef1fd7)
